### PR TITLE
Fix tag render

### DIFF
--- a/app/views/blog_entries/_tag_list.html.erb
+++ b/app/views/blog_entries/_tag_list.html.erb
@@ -1,3 +1,6 @@
 <div class="tags">
-  <%= t('tags') + ': ' + e.tag_list.map {|tag| link_to tag, tag_path(tag) } * ", " %>
+  <%= t('tags') %>:
+  <% e.tag_list.each do |tag| %>
+    <%= link_to(tag, tag_path(tag)) %> 
+  <% end %>
 </div>


### PR DESCRIPTION
I don't know why, but the rendering code for tags was escaping the html entities when it rendered the blog.  This fixes it for me.
